### PR TITLE
shooter: Add telemetry for flywheels

### DIFF
--- a/components/shooter.py
+++ b/components/shooter.py
@@ -1,6 +1,6 @@
 from math import radians, tau
 
-from magicbot import tunable
+from magicbot import feedback, tunable
 from rev import CANSparkMax
 from wpilib import DigitalInput
 from wpimath.controller import PIDController
@@ -59,9 +59,11 @@ class Shooter:
         # rotate back motors so the cube is picked up by the flywheels
         self.back_motor_speed = BACK_MOTOR_SHOOTING_SPEED
 
+    @feedback
     def top_flywheel_error(self) -> float:
         return self.top_flywheel_speed - self.top_flywheel_encoder.getVelocity()
 
+    @feedback
     def bottom_flywheel_error(self) -> float:
         return self.bottom_flywheel_speed - self.bottom_flywheel_encoder.getVelocity()
 

--- a/components/shooter.py
+++ b/components/shooter.py
@@ -2,7 +2,7 @@ from math import radians, tau
 
 from magicbot import feedback, tunable
 from rev import CANSparkMax
-from wpilib import DigitalInput
+from wpilib import DigitalInput, SmartDashboard
 from wpimath.controller import PIDController
 
 from ids import DioChannels, SparkMaxIds
@@ -45,6 +45,11 @@ class Shooter:
         self.top_flywheel_speed_controller = PIDController(1.0, 0.0, 0.0)
         self.bottom_flywheel_speed_controller = PIDController(1.0, 0.0, 0.0)
         self.back_motor_speed_controller = PIDController(1.0, 0.0, 0.0)
+
+        SmartDashboard.putData("flywheel_top_pid", self.top_flywheel_speed_controller)
+        SmartDashboard.putData(
+            "flywheel_bottom_pid", self.bottom_flywheel_speed_controller
+        )
 
         self.loaded_switch = DigitalInput(DioChannels.loaded_shooter)
 


### PR DESCRIPTION
This sends the PID controllers and calculated error of the flywheels to the dashboard for quick tuning.