### PR TITLE
Run turret indexing in disabled

### DIFF
--- a/components/turret.py
+++ b/components/turret.py
@@ -41,7 +41,7 @@ class Turret:
             maxVelocity=MAX_ANGULAR_VELOCITY, maxAcceleration=MAX_ANGULAR_ACCELERATION
         )
         self.rotation_controller = ProfiledPIDControllerRadians(
-            32.0, 0.0, 0.0, rotation_contraints
+            8.0, 0.0, 0.0, rotation_contraints
         )
         # set index found var to false
         self.index_found = False

--- a/components/turret.py
+++ b/components/turret.py
@@ -121,6 +121,11 @@ class Turret:
     def on_disable(self) -> None:
         self.motor.setIdleMode(CANSparkMax.IdleMode.kCoast)
 
+    def disabled_periodic(self) -> None:
+        if self.has_found_index():
+            self.set_angle(self.get_angle())
+            self.rotation_controller.reset(self.get_angle())
+
     def maybe_rezero_off_limits_switches(self) -> None:
         if self.at_negative_limit():
             self.set_to_angle(NEGATIVE_LIMIT_ANGLE)

--- a/components/turret.py
+++ b/components/turret.py
@@ -11,7 +11,7 @@ from ids import DioChannels, SparkMaxIds
 GEAR_RATIO: float = (10 / 1) * (4 / 1) * (140 / 18)
 ANGLE_ERROR_TOLERANCE: float = radians(1)
 MAX_ANGULAR_VELOCITY: float = 12.0
-MAX_ANGULAR_ACCELERATION: float = 0.5
+MAX_ANGULAR_ACCELERATION: float = 2.0
 NEGATIVE_LIMIT_ANGLE: float = radians(-112)
 POSITIVE_LIMIT_ANGLE: float = radians(112)
 INDEX_SEARCH_VOLTAGE: float = 2.0

--- a/components/turret.py
+++ b/components/turret.py
@@ -107,6 +107,8 @@ class Turret:
 
     def on_enable(self) -> None:
         self.motor.setIdleMode(CANSparkMax.IdleMode.kBrake)
+        self.rotation_controller.reset(self.get_angle())
+        self.goal_angle = self.goal_angle()
 
     def on_disable(self) -> None:
         self.motor.setIdleMode(CANSparkMax.IdleMode.kCoast)
@@ -120,5 +122,4 @@ class Turret:
     # override the current angle to be angle
     def set_to_angle(self, angle):
         self.encoder.setPosition(angle)
-        self.rotation_controller.reset(angle)
         self.index_found = True

--- a/components/turret.py
+++ b/components/turret.py
@@ -80,11 +80,18 @@ class Turret:
         self.index_found = False
 
     def execute(self) -> None:
-        if self.at_negative_limit() and self.at_positive_limit():
+        self.maybe_rezero_off_limits_switches()
+
+        if self.at_positive_limit() and self.at_negative_limit():
             self.motor.setVoltage(0)
             return
+        if self.at_positive_limit():
+            self.motor.setVoltage(-INDEX_SEARCH_VOLTAGE)
+            return
+        if self.at_negative_limit():
+            self.motor.setVoltage(INDEX_SEARCH_VOLTAGE)
+            return
 
-        self.maybe_rezero_off_limits_switches()
 
         if self.index_found:
             # calculate pid output based off angle delta

--- a/components/turret.py
+++ b/components/turret.py
@@ -92,7 +92,6 @@ class Turret:
             self.motor.setVoltage(INDEX_SEARCH_VOLTAGE)
             return
 
-
         if self.index_found:
             # calculate pid output based off angle delta
             pid_output = self.rotation_controller.calculate(

--- a/components/turret.py
+++ b/components/turret.py
@@ -129,8 +129,10 @@ class Turret:
     def maybe_rezero_off_limits_switches(self) -> None:
         if self.at_negative_limit():
             self.set_to_angle(NEGATIVE_LIMIT_ANGLE)
+            self.rotation_controller.reset(NEGATIVE_LIMIT_ANGLE)
         if self.at_positive_limit():
             self.set_to_angle(POSITIVE_LIMIT_ANGLE)
+            self.rotation_controller.reset(POSITIVE_LIMIT_ANGLE)
 
     # override the current angle to be angle
     def set_to_angle(self, angle):

--- a/components/turret.py
+++ b/components/turret.py
@@ -99,13 +99,19 @@ class Turret:
             else:
                 self.motor.setVoltage(-INDEX_SEARCH_VOLTAGE)
 
+    def on_enable(self) -> None:
+        self.motor.setIdleMode(CANSparkMax.IdleMode.kBrake)
+
+    def on_disable(self) -> None:
+        self.motor.setIdleMode(CANSparkMax.IdleMode.kCoast)
+
     def maybe_rezero_off_limits_switches(self) -> None:
         if self.at_negative_limit():
             self.set_to_angle(NEGATIVE_LIMIT_ANGLE)
         if self.at_positive_limit():
             self.set_to_angle(POSITIVE_LIMIT_ANGLE)
-    
-    # override the current position to be angle
+
+    # override the current angle to be angle
     def set_to_angle(self, angle):
         self.encoder.setPosition(angle)
         self.rotation_controller.reset(angle)

--- a/components/turret.py
+++ b/components/turret.py
@@ -116,7 +116,7 @@ class Turret:
     def on_enable(self) -> None:
         self.motor.setIdleMode(CANSparkMax.IdleMode.kBrake)
         self.rotation_controller.reset(self.get_angle())
-        self.goal_angle = self.goal_angle()
+        self.goal_angle = self.get_angle()
 
     def on_disable(self) -> None:
         self.motor.setIdleMode(CANSparkMax.IdleMode.kCoast)

--- a/components/turret.py
+++ b/components/turret.py
@@ -76,6 +76,14 @@ class Turret:
     def has_found_index(self) -> bool:
         return self.index_found
 
+    @feedback
+    def position_error(self) -> bool:
+        return self.rotation_controller.getPositionError()
+
+    @feedback
+    def velocity_error(self) -> bool:
+        return self.rotation_controller.getVelocityError()
+
     def find_index(self) -> None:
         self.index_found = False
 

--- a/components/turret.py
+++ b/components/turret.py
@@ -116,7 +116,7 @@ class Turret:
     def on_enable(self) -> None:
         self.motor.setIdleMode(CANSparkMax.IdleMode.kBrake)
         self.rotation_controller.reset(self.get_angle())
-        self.goal_angle = self.get_angle()
+        self.set_angle(self.get_angle())
 
     def on_disable(self) -> None:
         self.motor.setIdleMode(CANSparkMax.IdleMode.kCoast)

--- a/robot.py
+++ b/robot.py
@@ -39,6 +39,7 @@ class Robot(magicbot.MagicRobot):
 
     def disabledPeriodic(self) -> None:
         self.turret_component.maybe_rezero_off_limits_switches()
+        self.turret_component.disabled_periodic()
 
     def autonomousInit(self) -> None:
         pass

--- a/robot.py
+++ b/robot.py
@@ -38,7 +38,7 @@ class Robot(magicbot.MagicRobot):
         pass
 
     def disabledPeriodic(self) -> None:
-        pass
+        self.turret_component.maybe_rezero_off_limits_switches()
 
     def autonomousInit(self) -> None:
         pass


### PR DESCRIPTION
Runs the turret indexing detection in disabled to allow manually moving the turret to its limit before matches, will still run the zeroing routine if it hasn't hit a limit yet when its enabled. To make moving it while disabled easier given it sets the motor to coast mode when disabled.