### PR TITLE
game: Add stricter get_fiducial_pose function

### DIFF
--- a/utilities/game.py
+++ b/utilities/game.py
@@ -1,15 +1,20 @@
+import typing
+
 import robotpy_apriltag
 import wpilib
+from wpimath.geometry import Pose3d
 
 apriltag_layout = robotpy_apriltag.loadAprilTagLayoutField(
     robotpy_apriltag.AprilTagField.k2023ChargedUp
 )
+get_fiducial_pose = typing.cast(
+    typing.Callable[[typing.Literal[1, 2, 3, 4, 5, 6, 7, 8]], Pose3d],
+    apriltag_layout.getTagPose,
+)
 
 FIELD_WIDTH = 8.0161
-tag_8 = apriltag_layout.getTagPose(8)
-tag_1 = apriltag_layout.getTagPose(1)
-# for type checker
-assert tag_8 is not None and tag_1 is not None
+tag_8 = get_fiducial_pose(8)
+tag_1 = get_fiducial_pose(1)
 FIELD_LENGTH = tag_1.x + tag_8.x
 
 


### PR DESCRIPTION
This adds a function that only accepts the valid tag IDs for this year's field and always returns a Pose3d.