### PR TITLE
Fix target offsets on red alliance

### DIFF
--- a/controllers/shooter.py
+++ b/controllers/shooter.py
@@ -113,8 +113,6 @@ class ShooterController(StateMachine):
         else:
             depth = 0.42 / 2.0
             height = -0.45
-        if game.is_red():
-            depth = -depth
 
         translation = Translation3d(depth, 0.0, height)
         transform = Transform3d(translation, Rotation3d())


### PR DESCRIPTION
In #37 we found that the goal height was going in the wrong direction on the red alliance.

It turns out it's correct for the blue alliance, as the rotation of the tag pose is rotating the offset when we perform the transform. Hence we can remove the attempted accounting for the alliance, as it's already accounted for by the tag's rotation.